### PR TITLE
Remove onchange_birth_province as broken:

### DIFF
--- a/l10n_it_fiscalcode/wizard/compute_fc.py
+++ b/l10n_it_fiscalcode/wizard/compute_fc.py
@@ -71,29 +71,6 @@ class WizardComputeFc(models.TransientModel):
 
         return res
 
-    @api.multi
-    @api.onchange('birth_province')
-    def onchange_birth_province(self):
-        self.ensure_one()
-
-        res = {'domain': {'birth_city': []}}
-
-        if not self.birth_city:
-            if self.birth_province:
-                # SMELLS: Add a foreign key in "res_city_it_code"
-                #          instead using the weak link "code" <-> "province".
-                #
-                city_ids = self.env['res.city.it.code'] \
-                    .search([('province', '=', self.birth_province.code)])
-                names = city_ids.mapped('names')
-                distinct_city_ids = self.env['res.city.it.code.distinct'] \
-                    .search([('name', 'in', names)])
-
-                res['domain']['birth_city'] \
-                    .append(('id', 'in', distinct_city_ids.ids))
-
-        return res
-
     def _get_national_code(self, birth_city, birth_prov, birth_date):
         """
         notes fields contains variation data while var_date may contain the


### PR DESCRIPTION
  File "/home/elbati/workspace/odoo/instances/odoo11/parts/l10n-italy/l10n_it_fiscalcode/wizard/compute_fc.py", line 88, in onchange_birth_province
    names = city_ids.mapped('names')
  File "/home/elbati/workspace/odoo/instances/odoo11/parts/odoo/odoo/models.py", line 4512, in mapped
    recs = recs._mapped_func(operator.itemgetter(name))
  File "/home/elbati/workspace/odoo/instances/odoo11/parts/odoo/odoo/models.py", line 4491, in _mapped_func
    vals = [func(rec) for rec in self]
  File "/home/elbati/workspace/odoo/instances/odoo11/parts/odoo/odoo/models.py", line 4491, in <listcomp>
    vals = [func(rec) for rec in self]
  File "/home/elbati/workspace/odoo/instances/odoo11/parts/odoo/odoo/models.py", line 4758, in __getitem__
    return self._fields[key].__get__(self, type(self))
KeyError: 'names'

Also, the last field of a form should influence previous fields